### PR TITLE
Add zfs-headers package to delphix-kernel

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -34,6 +34,7 @@ Architecture: any
 Depends: linux-@@PLATFORM@@,
          linux-tools-@@PLATFORM@@,
          zfs-modules-@@KVERS@@,
+         zfs-headers-@@KVERS@@,
          linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.


### PR DESCRIPTION
Add the zfs-headers package to the delphix-kernel package. Requires the changes in https://github.com/delphix/zfs/pull/69 .

pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/64/console
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1979/console (in progress)