### PR TITLE
DLPX-67514 [Backport of Issue DLPX-67499 to 6.0.0.0] Use the HWE kernel for the generic platform on Ubuntu 18.04

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -33,5 +33,4 @@ if [[ -z "$PLATFORM" ]]; then
 	exit 1
 fi
 
-sed "s/@@KVERS@@/$KVERS/g; s/@@PLATFORM@@/$PLATFORM/g" \
-	debian/control.in >debian/control
+sed "s/@@KVERS@@/$KVERS/g" "debian/control.$PLATFORM.in" >debian/control

--- a/debian/control.aws.in
+++ b/debian/control.aws.in
@@ -1,0 +1,42 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Source: delphix-kernel
+Section: metapackages
+Priority: optional
+Maintainer: Delphix Engineering <eng@delphix.com>
+Build-Depends: debhelper (>= 10), devscripts
+Standards-Version: 4.1.2
+
+#
+# The following meta-package consolidates all the kernel packages required
+# by the Delphix Appliance for a given platform. Note that delphix-kernel
+# only has dependencies on kernel modules and tools that are built for a
+# specific version of the kernel. Any tools that are not specific to a
+# particular kernel version should not be included here.
+#
+Package: delphix-kernel-@@KVERS@@
+Provides: delphix-kernel-aws, delphix-kernel
+Architecture: any
+Depends: linux-aws,
+         linux-tools-aws,
+         zfs-modules-@@KVERS@@,
+         zfs-headers-@@KVERS@@,
+         linux-image-@@KVERS@@,
+         connstat-module-@@KVERS@@
+Description: Kernel packages consolidation for the Delphix Appliance.
+  This package consolidates all the version-specific kernel modules and tools
+  required by the Delphix Appliance for a given platform.

--- a/debian/control.azure.in
+++ b/debian/control.azure.in
@@ -1,0 +1,42 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Source: delphix-kernel
+Section: metapackages
+Priority: optional
+Maintainer: Delphix Engineering <eng@delphix.com>
+Build-Depends: debhelper (>= 10), devscripts
+Standards-Version: 4.1.2
+
+#
+# The following meta-package consolidates all the kernel packages required
+# by the Delphix Appliance for a given platform. Note that delphix-kernel
+# only has dependencies on kernel modules and tools that are built for a
+# specific version of the kernel. Any tools that are not specific to a
+# particular kernel version should not be included here.
+#
+Package: delphix-kernel-@@KVERS@@
+Provides: delphix-kernel-azure, delphix-kernel
+Architecture: any
+Depends: linux-azure,
+         linux-tools-azure,
+         zfs-modules-@@KVERS@@,
+         zfs-headers-@@KVERS@@,
+         linux-image-@@KVERS@@,
+         connstat-module-@@KVERS@@
+Description: Kernel packages consolidation for the Delphix Appliance.
+  This package consolidates all the version-specific kernel modules and tools
+  required by the Delphix Appliance for a given platform.

--- a/debian/control.gcp.in
+++ b/debian/control.gcp.in
@@ -29,10 +29,10 @@ Standards-Version: 4.1.2
 # particular kernel version should not be included here.
 #
 Package: delphix-kernel-@@KVERS@@
-Provides: delphix-kernel-@@PLATFORM@@, delphix-kernel
+Provides: delphix-kernel-gcp, delphix-kernel
 Architecture: any
-Depends: linux-@@PLATFORM@@,
-         linux-tools-@@PLATFORM@@,
+Depends: linux-gcp,
+         linux-tools-gcp,
          zfs-modules-@@KVERS@@,
          zfs-headers-@@KVERS@@,
          linux-image-@@KVERS@@,

--- a/debian/control.generic.in
+++ b/debian/control.generic.in
@@ -1,0 +1,42 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Source: delphix-kernel
+Section: metapackages
+Priority: optional
+Maintainer: Delphix Engineering <eng@delphix.com>
+Build-Depends: debhelper (>= 10), devscripts
+Standards-Version: 4.1.2
+
+#
+# The following meta-package consolidates all the kernel packages required
+# by the Delphix Appliance for a given platform. Note that delphix-kernel
+# only has dependencies on kernel modules and tools that are built for a
+# specific version of the kernel. Any tools that are not specific to a
+# particular kernel version should not be included here.
+#
+Package: delphix-kernel-@@KVERS@@
+Provides: delphix-kernel-generic, delphix-kernel
+Architecture: any
+Depends: linux-generic-hwe-18.04,
+         linux-tools-generic-hwe-18.04,
+         zfs-modules-@@KVERS@@,
+         zfs-headers-@@KVERS@@,
+         linux-image-@@KVERS@@,
+         connstat-module-@@KVERS@@
+Description: Kernel packages consolidation for the Delphix Appliance.
+  This package consolidates all the version-specific kernel modules and tools
+  required by the Delphix Appliance for a given platform.

--- a/debian/control.kvm.in
+++ b/debian/control.kvm.in
@@ -1,0 +1,42 @@
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Source: delphix-kernel
+Section: metapackages
+Priority: optional
+Maintainer: Delphix Engineering <eng@delphix.com>
+Build-Depends: debhelper (>= 10), devscripts
+Standards-Version: 4.1.2
+
+#
+# The following meta-package consolidates all the kernel packages required
+# by the Delphix Appliance for a given platform. Note that delphix-kernel
+# only has dependencies on kernel modules and tools that are built for a
+# specific version of the kernel. Any tools that are not specific to a
+# particular kernel version should not be included here.
+#
+Package: delphix-kernel-@@KVERS@@
+Provides: delphix-kernel-kvm, delphix-kernel
+Architecture: any
+Depends: linux-kvm,
+         linux-tools-kvm,
+         zfs-modules-@@KVERS@@,
+         zfs-headers-@@KVERS@@,
+         linux-image-@@KVERS@@,
+         connstat-module-@@KVERS@@
+Description: Kernel packages consolidation for the Delphix Appliance.
+  This package consolidates all the version-specific kernel modules and tools
+  required by the Delphix Appliance for a given platform.


### PR DESCRIPTION
Clean backport of https://github.com/delphix/delphix-kernel/pull/8

Co-dependent change: https://github.com/delphix/linux-pkg/pull/70

##Testing
linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/release/job/kernel/job/pre-push/8/
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2541/