### PR TITLE
LB-291 Review delphix-kernel package dependencies

### DIFF
--- a/debian/control.aws.in
+++ b/debian/control.aws.in
@@ -31,12 +31,14 @@ Standards-Version: 4.1.2
 Package: delphix-kernel-@@KVERS@@
 Provides: delphix-kernel-aws, delphix-kernel
 Architecture: any
-Depends: linux-aws,
-         linux-tools-aws,
+Depends: linux-image-@@KVERS@@,
+         linux-image-@@KVERS@@-dbgsym,
+         linux-modules-extra-@@KVERS@@,
+         linux-headers-@@KVERS@@,
+         linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,
          zfs-modules-@@KVERS@@-dbg,
          zfs-headers-@@KVERS@@,
-         linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.
   This package consolidates all the version-specific kernel modules and tools

--- a/debian/control.azure.in
+++ b/debian/control.azure.in
@@ -31,12 +31,14 @@ Standards-Version: 4.1.2
 Package: delphix-kernel-@@KVERS@@
 Provides: delphix-kernel-azure, delphix-kernel
 Architecture: any
-Depends: linux-azure,
-         linux-tools-azure,
+Depends: linux-image-@@KVERS@@,
+         linux-image-@@KVERS@@-dbgsym,
+         linux-modules-extra-@@KVERS@@,
+         linux-headers-@@KVERS@@,
+         linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,
          zfs-modules-@@KVERS@@-dbg,
          zfs-headers-@@KVERS@@,
-         linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.
   This package consolidates all the version-specific kernel modules and tools

--- a/debian/control.gcp.in
+++ b/debian/control.gcp.in
@@ -31,12 +31,14 @@ Standards-Version: 4.1.2
 Package: delphix-kernel-@@KVERS@@
 Provides: delphix-kernel-gcp, delphix-kernel
 Architecture: any
-Depends: linux-gcp,
-         linux-tools-gcp,
+Depends: linux-image-@@KVERS@@,
+         linux-image-@@KVERS@@-dbgsym,
+         linux-modules-extra-@@KVERS@@,
+         linux-headers-@@KVERS@@,
+         linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,
          zfs-modules-@@KVERS@@-dbg,
          zfs-headers-@@KVERS@@,
-         linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.
   This package consolidates all the version-specific kernel modules and tools

--- a/debian/control.generic.in
+++ b/debian/control.generic.in
@@ -31,12 +31,14 @@ Standards-Version: 4.1.2
 Package: delphix-kernel-@@KVERS@@
 Provides: delphix-kernel-generic, delphix-kernel
 Architecture: any
-Depends: linux-generic-hwe-18.04,
-         linux-tools-generic-hwe-18.04,
+Depends: linux-image-@@KVERS@@,
+         linux-image-@@KVERS@@-dbgsym,
+         linux-modules-extra-@@KVERS@@,
+         linux-headers-@@KVERS@@,
+         linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,
          zfs-modules-@@KVERS@@-dbg,
          zfs-headers-@@KVERS@@,
-         linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.
   This package consolidates all the version-specific kernel modules and tools

--- a/debian/control.oracle.in
+++ b/debian/control.oracle.in
@@ -31,12 +31,14 @@ Standards-Version: 4.1.2
 Package: delphix-kernel-@@KVERS@@
 Provides: delphix-kernel-oracle, delphix-kernel
 Architecture: any
-Depends: linux-oracle,
-         linux-tools-oracle,
+Depends: linux-image-@@KVERS@@,
+         linux-image-@@KVERS@@-dbgsym,
+         linux-modules-extra-@@KVERS@@,
+         linux-headers-@@KVERS@@,
+         linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,
          zfs-modules-@@KVERS@@-dbg,
          zfs-headers-@@KVERS@@,
-         linux-image-@@KVERS@@,
          connstat-module-@@KVERS@@
 Description: Kernel packages consolidation for the Delphix Appliance.
   This package consolidates all the version-specific kernel modules and tools


### PR DESCRIPTION
See JIRA for more info

## Testing
- ab-pre-push on aws: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3382/
- ab-pre-push on esx: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3383/
- ab-pre-push to build images for aws, esx, gcp, azure, oracle: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3380/ (The "oracle" part failed because it's not a valid platform. See next test)
- ab-pre-push to build images for oci: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3381/