### PR TITLE
DLPX-98314 delphix-kernel: control.{aws,generic}.in still Depend on linux-modules-extra, which Ubuntu dropped for those flavors in 7.0

### DIFF
--- a/debian/control.aws.in
+++ b/debian/control.aws.in
@@ -33,7 +33,6 @@ Provides: delphix-kernel-aws, delphix-kernel
 Architecture: any
 Depends: linux-image-@@KVERS@@,
          linux-image-@@KVERS@@-dbgsym,
-         linux-modules-extra-@@KVERS@@,
          linux-headers-@@KVERS@@,
          linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,

--- a/debian/control.generic.in
+++ b/debian/control.generic.in
@@ -33,7 +33,6 @@ Provides: delphix-kernel-generic, delphix-kernel
 Architecture: any
 Depends: linux-image-@@KVERS@@,
          linux-image-@@KVERS@@-dbgsym,
-         linux-modules-extra-@@KVERS@@,
          linux-headers-@@KVERS@@,
          linux-tools-@@KVERS@@,
          zfs-modules-@@KVERS@@,


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

appliance-build fails to install the appliance image once a flavor's Ubuntu base drops the `linux-modules-extra` package split for that kernel line:

* **aws**: linux-kernel-aws#72 (rebase onto Ubuntu-aws-7.0-7.0.0-1009.9_24.04.1):
  ```
  delphix-kernel-7.0.0-1009-dx2026080418-69ffacf47-aws : Depends: linux-modules-extra-7.0.0-1009-dx2026080418-69ffacf47-aws but it is not installable
  ```
* **generic** (kvm/esx): every post-push/nightly build since 2026-08-08, once linux-kernel-generic#57 (DLPX-98112) rebased onto Ubuntu-hwe-7.0-7.0.0-28.28_24.04.1:
  ```
  delphix-kernel-7.0.0-28-dx2026080722-e92af378a-generic : Depends: linux-modules-extra-7.0.0-28-dx2026080722-e92af378a-generic but it is not installable
  ```

Both are the same fleet-wide Canonical initiative ([Launchpad #2042831](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2042831)) dropping the modules-extra split flavor by flavor. Each time it lands for a flavor, that flavor's `debian.<flavor>/control.d/flavour-control.stub` loses its `linux-modules-extra-PKGVER-ABINUM-FLAVOUR` stanza and `rules.d/amd64.mk` stops setting `do_extras_package = true` — but this repo's `debian/control.<flavor>.in` keeps hard-declaring `Depends: linux-modules-extra-@@KVERS@@`, so apt can never satisfy it once that flavor's base drops the split.

This PR originally only touched `control.aws.in`, on the reasoning that other flavors' bases still shipped the split — true when opened (2026-08-05), but no longer true for generic once linux-kernel-generic#57 landed on 2026-08-07 (DLPX-98407, folded into DLPX-98314).
</summary>
</details>

<details open>
<summary><h2> Solution </h2></summary>

Remove `linux-modules-extra-@@KVERS@@` from the `Depends:` list in `debian/control.aws.in` and `debian/control.generic.in`.

`control.oracle.in`, `control.gcp.in`, and `control.azure.in` are intentionally left untouched — those flavors' Ubuntu bases still ship the modules-extra split today. Removing the dependency preemptively for those flavors would be a silent functional regression, since apt would simply stop requiring a package that still exists rather than erroring, so driver/module content would quietly stop being installed by default until something broke in the field. Each other flavor should get this same treatment only once its own base tag actually drops the split.
</summary>
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

**aws**: Validated with `git ab-pre-push` using `--extra-repo` to combine this fix branch with the linux-kernel-aws#72 patchset and the zfs sockaddr_unsized fix (delphix/zfs#2305, DLPX-98297), rerunning the full appliance-build-orchestrator-pre-push (build #14734, `PLATFORMS=aws`). Compile stage SUCCESS (`appliance-build » pre-push #7165`). Test stage: `upgrade-testing #4621` → `blackbox-chained #9578`: FAILURE, 2/49 failures — an SSH connectivity timeout mid-upgrade (`test_upgrade_linux_system`), matching a known unresolved infra flake ([DLPXQA-53392](https://perforce.atlassian.net/browse/DLPXQA-53392)) rather than a regression from this fix or the rebase.

**generic**: the `control.generic.in` change is new to this PR (added for DLPX-98407) and has not yet had its own combined `ab-pre-push` run with the linux-kernel-generic#57 patchset — will add that result here before merge. Note the earlier "generic: UNSTABLE, 0/97" result recorded against this PR was from linux-kernel-generic#57's own standalone pre-push run, which did not include this delphix-kernel branch (build #14734 above only built `PLATFORMS=aws`) — it doesn't validate the generic fix in this PR.
</summary>
</details>